### PR TITLE
package.json: Unify tabs/spaces convention

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"coffee-script": "1.8.0",
 		"node-uuid": "1.4.1",
-        "htpasswd": "2.1.6"
+		"htpasswd": "2.1.6"
 	},
 	"devDependencies": {
 		"nodeunit": "0.9.0",
@@ -38,8 +38,8 @@
 	"engines": {
 		"node": ">=0.4.1"
 	},
-   "scripts": {
-      "test": "node ./node_modules/nodeunit/bin/nodeunit tests"
-   },
+	"scripts": {
+		"test": "node ./node_modules/nodeunit/bin/nodeunit tests"
+	},
 	"keywords": ["node", "http", "server", "basic", "digest", "access", "authentication"]
 }


### PR DESCRIPTION
package.json uses both tabs and spaces for indentation, which led to confusion when using an editor with a different tab width than yours.  Since most of the file seems to be using tabs, I have switched the spaces over.