### PR TITLE
Refactor Authorization header parsing

### DIFF
--- a/lib/auth/digest.coffee
+++ b/lib/auth/digest.coffee
@@ -28,7 +28,6 @@ class Digest extends Base
   # Parse authorization header.
   parseAuthorization: (header) ->
     results = {}
-    parameterPairs = []
     isInQuotes = false
     lastStringStartingBoundary = 0
 

--- a/lib/auth/digest.coffee
+++ b/lib/auth/digest.coffee
@@ -31,14 +31,15 @@ class Digest extends Base
     parts = header.split(' ')
     params = parts.slice(1).join(' ')
     tokens = params.split(/,(?=(?:[^"]|"[^"]*")*$)/) #split the parameters by comma
-                    
+
     i = 0
     len = tokens.length
     while i < len
-      param = /(\w+)=["]?([^"]+)["]?$/.exec(tokens[i]) #strip quotes and whitespace
+      param = /(\w+)=["]?([^"]*)["]?$/.exec(tokens[i]) #strip quotes and whitespace
       if param
         opts[param[1]] = param[2]
       i++
+
     opts
   
   # Validating hash.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	"devDependencies": {
 		"nodeunit": "0.9.0",
 		"express": "3.3.8",
-		"http-proxy": "1.4.2",
+		"http-proxy": "1.11.1",
 		"request": "2.27.0"
 	},
 	"engines": {


### PR DESCRIPTION
Current implementation is not RFC compliant. It breaks on URI's with commas and probably in other cases as well.
Suggesting alternative implementation, based on passport-http digest implementation