### PR TITLE
Adding a callback to provide htpasswd user data

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Please check [examples directory](./examples) for more.
  - `file` - File where user details are stored.
      - Line format is **{user:pass}** or **{user:passHash}** for basic access. 
      - Line format is **{user:realm:passHash}** for digest access.
+     - Using a callback, it needs to return the same line format, example: `file: () => 'adam:adam\neve:eve',`
  - `algorithm` - Algorithm that will be used only for **digest** access authentication.
      - **MD5** by default.
      - **MD5-sess** can be set.

--- a/src/auth/base.js
+++ b/src/auth/base.js
@@ -143,10 +143,12 @@ class Base extends events.EventEmitter {
     }
   }
 
-  // Loading files with user details.
+  // Loading files or using a callback with user details.
   loadUsers() {
-    let users = fs
-      .readFileSync(this.options.file, "UTF-8")
+    let content = (typeof this.options.file == "function")
+      ? this.options.file(this)
+      : fs.readFileSync(this.options.file, "UTF-8");
+    let users = content
       .replace(/\r\n/g, "\n")
       .split("\n");
 


### PR DESCRIPTION
I needed to add a user / users from commandline when starting the script.

Not to need streams or any fancy stuff in the http-auth module, I thought, this might make it possible with the least impact on the module.

Reading all Pull-Requests and some Issues, I believe there was no attempt to this yet.
Feel free to reject :)